### PR TITLE
Upgrade mocha to 6.x.x release

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "acorn": "^6.1.0",
     "eslint": "^5.13.0",
     "eslint-plugin-node": "^8.0.1",
-    "mocha": "^5.2.0",
+    "mocha": "^6.2.3",
     "test262": "git+https://github.com/tc39/test262.git#33a306d1026b72227eb50a918db19ada16f12b3d",
     "test262-parser-runner": "^0.5.0"
   },


### PR DESCRIPTION
Upgrades to the latest [mocha release](https://github.com/mochajs/mocha/releases/tag/v6.2.3); tests are passing.