### PR TITLE
Update AST node names to match ESTree [breaking change]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a plugin for [Acorn](http://marijnhaverbeke.nl/acorn/) - a tiny, fast JavaScript parser, written completely in JavaScript.
 
-It implements support for static class features as defined in the stage 3 proposal [Static class features](https://github.com/tc39/proposal-static-class-features). The emitted AST follows [an ESTree proposal](https://github.com/estree/estree/pull/180).
+It implements support for static class features as defined in the stage 3 proposal [Static class features](https://github.com/tc39/proposal-static-class-features). The emitted AST follows the [ESTree experimental Class Features design](https://github.com/estree/estree/blob/master/experimental/class-features.md).
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function(Parser) {
 
       const branch = this._branch()
       branch.next()
-      if ([tt.name, tt.bracketL, tt.string, tt.num, this.privateNameToken].indexOf(branch.type) == -1 && !branch.type.keyword) {
+      if ([tt.name, tt.bracketL, tt.string, tt.num, this.privateIdentifierToken].indexOf(branch.type) == -1 && !branch.type.keyword) {
         return super.parseClassElement.apply(this, arguments)
       }
       if (branch.type == tt.bracketL) {
@@ -43,7 +43,7 @@ module.exports = function(Parser) {
 
       const node = this.startNode()
       node.static = this.eatContextual("static")
-      if (this.type == this.privateNameToken) {
+      if (this.type == this.privateIdentifierToken) {
         this.parsePrivateClassElementName(node)
       } else {
         this.parsePropertyName(node)
@@ -59,14 +59,14 @@ module.exports = function(Parser) {
       this.enterScope(64 | 2 | 1) // See acorn's scopeflags.js
       this._maybeParseFieldValue(node)
       this.exitScope()
-      this.finishNode(node, "FieldDefinition")
+      this.finishNode(node, "PropertyDefinition")
       this.semicolon()
       return node
     }
 
     // Parse private static methods
     parsePropertyName(prop) {
-      if (prop.static && this.type == this.privateNameToken) {
+      if (prop.static && this.type == this.privateIdentifierToken) {
         this.parsePrivateClassElementName(prop)
       } else {
         super.parsePropertyName(prop)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "acorn": "^6.1.0 || ^7 || ^8"
   },
-  "version": "0.2.4",
+  "version": "1.0.0",
   "devDependencies": {
     "acorn": "^8",
     "eslint": "^7",
@@ -31,6 +31,6 @@
     "test262-parser-runner": "^0.5.0"
   },
   "dependencies": {
-    "acorn-private-class-elements": "^0.2.7"
+    "acorn-private-class-elements": "^1.0.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -103,10 +103,10 @@ describe("acorn-static-class-features", function () {
           type: "ClassBody",
           end: body.end + 13,
           body: [body, newNode(body.end + 2, {
-            type: "FieldDefinition",
+            type: "PropertyDefinition",
             end: body.end + 11,
             key: newNode(body.end + 9, {
-              type: "PrivateName",
+              type: "PrivateIdentifier",
               end: body.end + 11,
               name: "y"
             }),
@@ -210,7 +210,7 @@ describe("acorn-static-class-features", function () {
 
   ;[
     { body: "static x", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 8,
       key: newNode(start + 7, {
         type: "Identifier",
@@ -222,7 +222,7 @@ describe("acorn-static-class-features", function () {
       static: true
     }) },
     { body: "static x = 0", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 12,
       key: newNode(start + 7, {
         type: "Identifier",
@@ -239,7 +239,7 @@ describe("acorn-static-class-features", function () {
       static: true
     }) },
     { body: "static [x]", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 10,
       computed: true,
       key: newNode(start + 8, {
@@ -251,7 +251,7 @@ describe("acorn-static-class-features", function () {
       static: true
     }) },
     { body: "static [x] = 0", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 14,
       computed: true,
       key: newNode(start + 8, {
@@ -268,11 +268,11 @@ describe("acorn-static-class-features", function () {
       static: true
     }) },
     { body: "static #x", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 9,
       computed: false,
       key: newNode(start + 7, {
-        type: "PrivateName",
+        type: "PrivateIdentifier",
         end: start + 9,
         name: "x"
       }),
@@ -280,11 +280,11 @@ describe("acorn-static-class-features", function () {
       static: true
     }) },
     { body: "static #x = 0", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 13,
       computed: false,
       key: newNode(start + 7, {
-        type: "PrivateName",
+        type: "PrivateIdentifier",
         end: start + 9,
         name: "x"
       }),
@@ -298,7 +298,7 @@ describe("acorn-static-class-features", function () {
     }) },
 
     { body: "static async", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 12,
       key: newNode(start + 7, {
         type: "Identifier",
@@ -311,7 +311,7 @@ describe("acorn-static-class-features", function () {
     }) },
 
     { body: "static async = 5", passes: true, ast: start => newNode(start, {
-      type: "FieldDefinition",
+      type: "PropertyDefinition",
       end: start + 16,
       key: newNode(start + 7, {
         type: "Identifier",
@@ -357,7 +357,7 @@ describe("acorn-static-class-features", function () {
       end: start + 14,
       computed: false,
       key: newNode(start + 7, {
-        type: "PrivateName",
+        type: "PrivateIdentifier",
         end: start + 9,
         name: "x"
       }),
@@ -383,7 +383,7 @@ describe("acorn-static-class-features", function () {
       end: start + 18,
       computed: false,
       key: newNode(start + 11, {
-        type: "PrivateName",
+        type: "PrivateIdentifier",
         end: start + 13,
         name: "x"
       }),


### PR DESCRIPTION
FieldDefinition -> PropertyDefinition
PrivateName -> PrivateIdentifier
privateNameToken -> privateIdentifierToker

This follows https://github.com/acornjs/acorn-private-class-elements/pull/16 and precedes a update to acorn-stage3.